### PR TITLE
Fix hyperlink syntax error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ Installation
 ---
 The two version of Auto-encoder - python version and C++ version.
 
-Python version has a pre-requisite of [https://github.com/douban/dpark](Dpark), which is a Python clone of Spark. I have mainly adopted Dpark as map-reduce programming, substituting those simple loops, and thus get accelerated. 
+Python version has a pre-requisite of [Dpark](https://github.com/douban/dpark), which is a Python clone of Spark. I have mainly adopted Dpark as map-reduce programming, substituting those simple loops, and thus get accelerated.
 
-Meanwhile, C++ version requires [http://paracel.io](paracel) as the parallel computing framework; paracel was produced by [http://douban.com](douban) following the idea of **Parameter Server** by Jeaf Dean @Google. Paracel could be easily applied in stochastic gradient descent alike training frameworks.
+Meanwhile, C++ version requires [paracel](http://paracel.io) as the parallel computing framework; paracel was produced by [douban](http://douban.com) following the idea of **Parameter Server** by Jeaf Dean @Google. Paracel could be easily applied in stochastic gradient descent alike training frameworks.
 
-Besides this, if you run the program on a shared pool of servers, I recommend you to deploy [http://mesos.apache.org/](mesos) to manage the cluster.
+Besides this, if you run the program on a shared pool of servers, I recommend you to deploy [mesos](http://mesos.apache.org/) to manage the cluster.
 
 Usage
 ----


### PR DESCRIPTION
The hyperlink syntax in README.md reverses the url part and description part. The PR is to fix it.
